### PR TITLE
Fix for playlist sharing

### DIFF
--- a/youtube-share.user.js
+++ b/youtube-share.user.js
@@ -9,7 +9,7 @@
 // @description Removes the tracking parameter(s) YouTube adds when using the Share button, and other annoyances
 // ==/UserScript==
 
-const allowedShareParams = ["t"];
+const allowedShareParams = ["t", "list"];
 
 const cleanUrl = (el) => {
     const url = new URL(el.value);


### PR DESCRIPTION
In the current version, when you try to share a playlist, URL looks like this
`https://youtube.com/playlist?si=xxxxxxxxxxxxx`
Share ID is present, but playlist ID is removed.
After this small fix URL looks like this
`https://youtube.com/playlist?list=xxxxxxxxxxxxx`